### PR TITLE
feat: add rows and columns capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ const { context, canvas } = canvasContext("2d", {
 });
 
 const grid = new PerspectiveGrid(context, 10);
+
+// Alternatively, you can define the number of rows and columns. In this example,
+// we would create a grid with 5 rows and 8 columns:
+// const grid = new PerspectiveGrid(context, [5, 8]);
+
 grid.init(
   new Point(300, 380),
   new Point(canvas.width - 300, 300),
@@ -93,7 +98,7 @@ context.restore();
 
 LineEquation defines a line equation or vertical
 
-**Kind**: Exported class  
+**Kind**: Exported class
 <a name="new_module_LineEquation--LineEquation_new"></a>
 
 #### new LineEquation(lineParams, x)
@@ -136,24 +141,24 @@ Get intersection of two line equation
 
 ### MathHelper.EPSILON : <code>number</code>
 
-**Kind**: static constant of [<code>MathHelper</code>](#module_MathHelper)  
+**Kind**: static constant of [<code>MathHelper</code>](#module_MathHelper)
 <a name="module_MathHelper.PI"></a>
 
 ### MathHelper.PI : <code>number</code>
 
-**Kind**: static constant of [<code>MathHelper</code>](#module_MathHelper)  
+**Kind**: static constant of [<code>MathHelper</code>](#module_MathHelper)
 <a name="module_MathHelper.TWO_PI"></a>
 
 ### MathHelper.TWO_PI : <code>number</code>
 
-**Kind**: static constant of [<code>MathHelper</code>](#module_MathHelper)  
+**Kind**: static constant of [<code>MathHelper</code>](#module_MathHelper)
 <a name="module_MathHelper.getDistance"></a>
 
 ### MathHelper.getDistance(point1, point2) ⇒ <code>number</code>
 
 Get the distance between two points
 
-**Kind**: static method of [<code>MathHelper</code>](#module_MathHelper)  
+**Kind**: static method of [<code>MathHelper</code>](#module_MathHelper)
 **Returns**: <code>number</code> - Distance between point1 and point2
 
 | Param  | Type                | Description  |
@@ -284,7 +289,7 @@ Two point perspective grid on canvas.
 
 Note: Does not work correctly when there is only one vanishing point.
 
-**Kind**: Exported class  
+**Kind**: Exported class
 <a name="new_module_PerspectiveGrid--PerspectiveGrid_new"></a>
 
 #### new PerspectiveGrid(context, units, [squares])
@@ -318,14 +323,14 @@ Reset the corners (clockwise starting from top left)
 
 Draw the grid in the instance context
 
-**Kind**: instance method of [<code>PerspectiveGrid</code>](#exp_module_PerspectiveGrid--PerspectiveGrid)  
+**Kind**: instance method of [<code>PerspectiveGrid</code>](#exp_module_PerspectiveGrid--PerspectiveGrid)
 <a name="module_PerspectiveGrid--PerspectiveGrid+update"></a>
 
 #### perspectiveGrid.update()
 
 Update grid segments
 
-**Kind**: instance method of [<code>PerspectiveGrid</code>](#exp_module_PerspectiveGrid--PerspectiveGrid)  
+**Kind**: instance method of [<code>PerspectiveGrid</code>](#exp_module_PerspectiveGrid--PerspectiveGrid)
 <a name="module_PerspectiveGrid--PerspectiveGrid+getQuadAt"></a>
 
 #### perspectiveGrid.getQuadAt(column, row) ⇒ <code>Array.&lt;Point&gt;</code>
@@ -358,14 +363,14 @@ Get the center point from grid unit to pixel eg. (1, 1) is the first top left po
 
 Actually draw the lines (vertical and horizontal) in the context
 
-**Kind**: instance method of [<code>PerspectiveGrid</code>](#exp_module_PerspectiveGrid--PerspectiveGrid)  
+**Kind**: instance method of [<code>PerspectiveGrid</code>](#exp_module_PerspectiveGrid--PerspectiveGrid)
 <a name="module_PerspectiveGrid--PerspectiveGrid+drawSquares"></a>
 
 #### perspectiveGrid.drawSquares()
 
 Draw highlighted squares in the grid
 
-**Kind**: instance method of [<code>PerspectiveGrid</code>](#exp_module_PerspectiveGrid--PerspectiveGrid)  
+**Kind**: instance method of [<code>PerspectiveGrid</code>](#exp_module_PerspectiveGrid--PerspectiveGrid)
 <a name="module_PerspectiveGrid--PerspectiveGrid+drawPoint"></a>
 
 #### perspectiveGrid.drawPoint(point, radius, color)
@@ -408,7 +413,7 @@ Get a line parallel to the horizon
 
 An object that defines a Point
 
-**Kind**: Exported class  
+**Kind**: Exported class
 <a name="new_module_Point--Point_new"></a>
 
 #### new Point(x, y)
@@ -445,7 +450,7 @@ Check if a point is in a list of points
 
 An object with two points that defines a segment
 
-**Kind**: Exported class  
+**Kind**: Exported class
 <a name="new_module_Segment--Segment_new"></a>
 
 #### new Segment(p1, p1)

--- a/README.md
+++ b/README.md
@@ -35,11 +35,8 @@ const { context, canvas } = canvasContext("2d", {
   height: window.innerHeight,
 });
 
+// Alternatively pass [rows, columns] for a grid with different rows and column units
 const grid = new PerspectiveGrid(context, 10);
-
-// Alternatively, you can define the number of rows and columns. In this example,
-// we would create a grid with 5 rows and 8 columns:
-// const grid = new PerspectiveGrid(context, [5, 8]);
 
 grid.init(
   new Point(300, 380),

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
         new Point(7, 8),
       ];
 
-      const grid = new PerspectiveGrid(context, 10, squares);
+      const grid = new PerspectiveGrid(context, [10, 20], squares);
 
       const grids = {
         top: [

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 export { default as default } from "./src/PerspectiveGrid.js";
 
 export { default as LineEquation } from "./src/LineEquation.js";
+export { default as LineType } from "./src/LineType.js";
 export * as MathHelper from "./src/MathHelper.js";
 export { default as Point } from "./src/Point.js";
 export { default as Segment } from "./src/Segment.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "perspective-grid",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
+      "version": "2.1.0",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perspective-grid",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Two point perspective grid on canvas.",
   "keywords": [
     "canvas",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perspective-grid",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "Two point perspective grid on canvas.",
   "keywords": [
     "canvas",

--- a/src/LineType.js
+++ b/src/LineType.js
@@ -1,12 +1,17 @@
 /**
  * @module LineType
- *
- * A faked ENUM for referencing line types.
  */
 
+/**
+ * A faked ENUM for referencing line types.
+ *
+ * @alias module:LineType
+ * @param {number} VERTICAL
+ * @param {number} HORIZONTAL
+ */
 const LineType = Object.freeze({
   VERTICAL: 1,
   HORIZONTAL: 2,
-})
+});
 
 export default LineType;

--- a/src/LineType.js
+++ b/src/LineType.js
@@ -1,0 +1,12 @@
+/**
+ * @module LineType
+ *
+ * A faked ENUM for referencing line types.
+ */
+
+const LineType = Object.freeze({
+  VERTICAL: 1,
+  HORIZONTAL: 2,
+})
+
+export default LineType;

--- a/src/PerspectiveGrid.js
+++ b/src/PerspectiveGrid.js
@@ -19,15 +19,12 @@ class PerspectiveGrid {
   /**
    * Creates an instance of PerspectiveGrid.
    * @param {CanvasRenderingContext2D} context The context to draw the grid in
-   * @param {number|array} units
-   * If numeric, number of rows and columns. If array, follow the following
-   * format: [rows, columns].
-   *
+   * @param {number|Array<number>} units Number of rows and columns (unit or [rows, columns]).
    * @param {Array<Point>} [squares] Highlighted squares in the grid
    */
   constructor(context, units, squares) {
     this.context = context;
-    this._assignRowsAndColumns(units);
+    [this.rows, this.columns] = Array.isArray(units) ? units : [units, units];
     this.squares = squares || [];
   }
 
@@ -274,43 +271,6 @@ class PerspectiveGrid {
   }
 
   /**
-   * Assign the rows and columns based on the passed units.
-   *
-   * @param {number|array} units
-   *   Must either be a number or an array consisting of number of rows and
-   *   columns like so: [rows, columns].
-   *
-   * @private
-   */
-  _assignRowsAndColumns(units) {
-    const errorMsg = 'Passed units must be either a number or an array consisting of rows and columns';
-    let rows, columns;
-
-    if (typeof(units) === 'number') {
-      rows = parseInt(units, 10);
-      columns = parseInt(units, 10);
-    } else if (Array.isArray(units)) {
-      if (units.length !== 2) {
-        throw new TypeError(errorMsg);
-      }
-
-      units.filter(function(unit) {
-        if (isNaN(unit)) {
-          throw new TypeError(errorMsg);
-        }
-      });
-
-      rows = parseInt(units[0], 10);
-      columns = parseInt(units[1], 10);
-    } else {
-      throw new TypeError(errorMsg);
-    }
-
-    this.rows = rows;
-    this.columns = columns;
-  }
-
-  /**
    * Update lines (vertical and horizontal) equations
    * @private
    * @param {LineEquation} side
@@ -374,17 +334,16 @@ class PerspectiveGrid {
    * Get line equations for equidistant lines
    * @private
    */
-  _getEquidistantLines(lineType, sideStart, sideEnd, matchingStart, matchingEnd) {
+  _getEquidistantLines(
+    lineType,
+    sideStart,
+    sideEnd,
+    matchingStart,
+    matchingEnd
+  ) {
     let lines = [];
 
-    let units;
-    if (lineType === LineType.HORIZONTAL) {
-      units = this.rows;
-    } else if (lineType === LineType.VERTICAL) {
-      units = this.columns;
-    } else {
-      throw new TypeError('Must define a valid line type when getting lines');
-    }
+    const units = lineType === LineType.HORIZONTAL ? this.rows : this.columns;
 
     const delta = new Point(
       (sideEnd.x - sideStart.x) / units,
@@ -419,11 +378,11 @@ class PerspectiveGrid {
   /**
    * Draw line from horizon to vanishing point
    * @private
-   * @param  {number} lineType   An enum value from LineType.
+   * @param  {LineType} lineType
    * @param  {LineEquation} side
    * @param  {LineEquation} oppositeSide
    * @param  {LineEquation} horizon
-   * @param  {Point}        vanishingPoint
+   * @param  {Point} vanishingPoint
    * @return {Array<LineEquation>}
    */
   _getLines(lineType, side, oppositeSide, horizon, vanishingPoint) {
@@ -440,14 +399,7 @@ class PerspectiveGrid {
       projectedOppositeSide.y - projectedSide.y
     );
 
-    let units;
-    if (lineType === LineType.HORIZONTAL) {
-      units = this.rows;
-    } else if (lineType === LineType.VERTICAL) {
-      units = this.columns;
-    } else {
-      throw new TypeError('Must define a valid line type when getting lines');
-    }
+    const units = lineType === LineType.HORIZONTAL ? this.rows : this.columns;
 
     const dx = distance.x / units;
     const dy = distance.y / units;

--- a/src/PerspectiveGrid.js
+++ b/src/PerspectiveGrid.js
@@ -5,6 +5,7 @@
 import Point from "./Point.js";
 import Segment from "./Segment.js";
 import LineEquation from "./LineEquation.js";
+import LineType from "./LineType.js";
 import * as MathHelper from "./MathHelper.js";
 
 /**
@@ -18,14 +19,15 @@ class PerspectiveGrid {
   /**
    * Creates an instance of PerspectiveGrid.
    * @param {CanvasRenderingContext2D} context The context to draw the grid in
-   * @param {number} units Number of rows and columns
+   * @param {number|array} units
+   * If numeric, number of rows and columns. If array, follow the following
+   * format: [rows, columns].
+   *
    * @param {Array<Point>} [squares] Highlighted squares in the grid
    */
   constructor(context, units, squares) {
-    this._lineCount = units + 1;
-    this.gridUnitCount = units;
     this.context = context;
-
+    this._assignRowsAndColumns(units);
     this.squares = squares || [];
   }
 
@@ -45,8 +47,8 @@ class PerspectiveGrid {
     this.horizontal = [];
     this.vertical = [];
 
-    const dy = (this._bl.y - this._tl.y) / this.gridUnitCount;
-    const dx = (this._tr.x - this._tl.x) / this.gridUnitCount;
+    const dy = (this._bl.y - this._tl.y) / this.rows;
+    const dx = (this._tr.x - this._tl.x) / this.columns;
 
     for (let y = this._tl.y; y <= this._bl.y + MathHelper.EPSILON; y += dy) {
       this.horizontal[this.horizontal.length] = new Segment(
@@ -130,20 +132,34 @@ class PerspectiveGrid {
     // Compute segment positions
     if (horizon === null) {
       horizontal = this._getEquidistantLines(
+        LineType.HORIZONTAL,
         this._tl,
         this._bl,
         this._tr,
         this._br
       );
       vertical = this._getEquidistantLines(
+        LineType.VERTICAL,
         this._tl,
         this._tr,
         this._bl,
         this._br
       );
     } else {
-      horizontal = this._getLines(topLine, bottomLine, horizon, hVanishing);
-      vertical = this._getLines(leftLine, rightLine, horizon, vVanishing);
+      horizontal = this._getLines(
+        LineType.HORIZONTAL,
+        topLine,
+        bottomLine,
+        horizon,
+        hVanishing
+      );
+      vertical = this._getLines(
+        LineType.VERTICAL,
+        leftLine,
+        rightLine,
+        horizon,
+        vVanishing
+      );
     }
 
     this._updateLines(topLine, bottomLine, vertical, this.vertical);
@@ -215,7 +231,7 @@ class PerspectiveGrid {
     for (let i = 0; i < points.length; i++) {
       const point = points[i];
 
-      if (point.x > this.gridUnitCount || point.y > this.gridUnitCount) {
+      if (point.x > this.columns || point.y > this.rows) {
         throw new Error(`Point ${point.x}, ${point.x} is not in the grid.`);
       }
 
@@ -255,6 +271,43 @@ class PerspectiveGrid {
     this.context.fillStyle = color || "grey";
     this.context.fill();
     this.context.restore();
+  }
+
+  /**
+   * Assign the rows and columns based on the passed units.
+   *
+   * @param {number|array} units
+   *   Must either be a number or an array consisting of number of rows and
+   *   columns like so: [rows, columns].
+   *
+   * @private
+   */
+  _assignRowsAndColumns(units) {
+    const errorMsg = 'Passed units must be either a number or an array consisting of rows and columns';
+    let rows, columns;
+
+    if (typeof(units) === 'number') {
+      rows = parseInt(units, 10);
+      columns = parseInt(units, 10);
+    } else if (Array.isArray(units)) {
+      if (units.length !== 2) {
+        throw new TypeError(errorMsg);
+      }
+
+      units.filter(function(unit) {
+        if (isNaN(unit)) {
+          throw new TypeError(errorMsg);
+        }
+      });
+
+      rows = parseInt(units[0], 10);
+      columns = parseInt(units[1], 10);
+    } else {
+      throw new TypeError(errorMsg);
+    }
+
+    this.rows = rows;
+    this.columns = columns;
   }
 
   /**
@@ -321,18 +374,28 @@ class PerspectiveGrid {
    * Get line equations for equidistant lines
    * @private
    */
-  _getEquidistantLines(sideStart, sideEnd, matchingStart, matchingEnd) {
+  _getEquidistantLines(lineType, sideStart, sideEnd, matchingStart, matchingEnd) {
     let lines = [];
+
+    let units;
+    if (lineType === LineType.HORIZONTAL) {
+      units = this.rows;
+    } else if (lineType === LineType.VERTICAL) {
+      units = this.columns;
+    } else {
+      throw new TypeError('Must define a valid line type when getting lines');
+    }
+
     const delta = new Point(
-      (sideEnd.x - sideStart.x) / this.gridUnitCount,
-      (sideEnd.y - sideStart.y) / this.gridUnitCount
+      (sideEnd.x - sideStart.x) / units,
+      (sideEnd.y - sideStart.y) / units
     );
     const matchingDelta = new Point(
-      (matchingEnd.x - matchingStart.x) / this.gridUnitCount,
-      (matchingEnd.y - matchingStart.y) / this.gridUnitCount
+      (matchingEnd.x - matchingStart.x) / units,
+      (matchingEnd.y - matchingStart.y) / units
     );
 
-    for (let i = 0; i < this._lineCount; i++) {
+    for (let i = 0; i <= units; i++) {
       const begin = new Point(
         sideStart.x + i * delta.x,
         sideStart.y + i * delta.y
@@ -356,13 +419,14 @@ class PerspectiveGrid {
   /**
    * Draw line from horizon to vanishing point
    * @private
+   * @param  {number} lineType   An enum value from LineType.
    * @param  {LineEquation} side
    * @param  {LineEquation} oppositeSide
    * @param  {LineEquation} horizon
    * @param  {Point}        vanishingPoint
    * @return {Array<LineEquation>}
    */
-  _getLines(side, oppositeSide, horizon, vanishingPoint) {
+  _getLines(lineType, side, oppositeSide, horizon, vanishingPoint) {
     // Project sides onto the horizon
     const projectedSide = side.intersect(horizon);
     const projectedOppositeSide = oppositeSide.intersect(horizon);
@@ -375,12 +439,22 @@ class PerspectiveGrid {
       projectedOppositeSide.x - projectedSide.x,
       projectedOppositeSide.y - projectedSide.y
     );
-    const dx = distance.x / this.gridUnitCount;
-    const dy = distance.y / this.gridUnitCount;
+
+    let units;
+    if (lineType === LineType.HORIZONTAL) {
+      units = this.rows;
+    } else if (lineType === LineType.VERTICAL) {
+      units = this.columns;
+    } else {
+      throw new TypeError('Must define a valid line type when getting lines');
+    }
+
+    const dx = distance.x / units;
+    const dy = distance.y / units;
 
     let results = [];
 
-    for (let i = 0; i < this._lineCount; i++) {
+    for (let i = 0; i <= units; i++) {
       const startPoint = new Point(
         projectedSide.x + i * dx,
         projectedSide.y + i * dy


### PR DESCRIPTION
* Previously, when instantiating a PerspectiveGrid instance, you could
  only define the amount of rows and columns as a single number. This
  meant that if you wanted your rows and columns to be different, it
  wasn't possible. We have now allowed PerspectiveGrid to be instantied
  with an array of rows and columns like so:
  `new PerspectiveGrid(context, [5, 8])`. In this example you are
  defining the grid to have 5 rows and 8 columns.

----

Please let me know if you want anything adjusted or anything looks off, thanks!